### PR TITLE
Урок 4. Роутинг в React: разбиваем мессенджер на чаты

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,8 @@ build/Release
 node_modules/
 jspm_packages/
 
+package-lock.json
+
 # TypeScript v1 declaration files
 typings/
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "gb201220",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "webpack": "./node_modules/webpack/bin/webpack.js",
+    "dev": "npm run webpack serve"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@babel/cli": "^7.12.10",
+    "@babel/core": "^7.12.10",
+    "@babel/plugin-proposal-class-properties": "^7.12.1",
+    "@babel/preset-env": "^7.12.11",
+    "@babel/preset-react": "^7.12.10",
+    "babel-loader": "^8.2.2",
+    "clean-webpack-plugin": "^3.0.0",
+    "css-loader": "^5.0.1",
+    "html-webpack-plugin": "^4.5.0",
+    "material-ui": "^0.20.2",
+    "prop-types": "^15.7.2",
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1",
+    "react-router-dom": "^5.2.0",
+    "style-loader": "^2.0.0",
+    "webpack": "^5.11.0",
+    "webpack-cli": "^4.2.0",
+    "webpack-dev-server": "^3.11.0"
+  }
+}

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import {BrowserRouter, Switch, Route, Link} from 'react-router-dom';
+
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+
+import Message from './Message.jsx';
+import Example from './Example';
+import MessageList from './MessageList';
+import SendMessage from './SendMessage';
+import Messages from './pages/Messages';
+
+import '../styles/App.css';
+
+export default class App extends React.Component {
+
+    constructor(props){
+        super(props);
+
+        this.state = {
+            text: 'Some text from state',
+            timeout: null,
+            messages: [],
+            interval: null
+        };
+    }
+
+    // componentDidMount(){
+    //     console.log('componentDidMount');
+    //     // const timeout = setTimeout(
+    //     //     () => {
+    //     //         this.setState({messages: [...this.state.messages, 'I do not answer you. I am robot']});
+    //     //     },
+    //     //     500
+    //     // );
+    //     // const interval = setInterval(
+    //     //     () => {
+    //     //         this.setState({messages: [...this.state.messages, 'How are you?']});
+    //     //         setTimeout(
+    //     //             () => this.setState({messages: [...this.state.messages, 'I do not answer you. I am robot']}),
+    //     //             1000
+    //     //         );
+    //     //     },
+    //     //     2000
+    //     // );
+    //     // this.setState({timeout});
+    //     // this.setState({interval});
+    //     // fetch()....then(res => { ...... this.setState(...) })
+    // }
+
+    componentDidUpdate(prevProps, prevState){
+        console.log('componentWillUpdate');
+        console.log(this.state.messages.length, this.state.messages.length % 2);
+        //if(this.state.messages.length % 2 > 0){
+	  if (prevState.messages.length < this.state.messages.length && this.state.messages[this.state.messages.length - 1].author === 'me'){
+            // console.log();
+            const timeout = setTimeout(
+                () => {
+                    this.setState({messages: [...this.state.messages, {message: 'Hello! I am robot', author: 'robot'}]});
+                    this.setState({timeout});
+                },
+                2000
+            );
+            // this.setState({timeout});
+        }
+    }
+
+    componentWillUnmount(){
+        clearTimeout(this.state.timeout);
+        // clearInterval(this.state.interval);
+        this.setState({timeout: null});
+        // this.setState({interval: null});
+    }
+
+    send = objMsg => {
+        this.setState({messages: [...this.state.messages, objMsg]});
+        // const timeout = setTimeout(
+        //     () => {
+        //         this.setState({messages: [...this.state.messages, {message: 'I do not answer you. I am robot', author: 'robot'}]});
+        //     },
+        //     1000
+        // );
+        // this.setState({timeout});
+    };
+
+    render() {
+        console.log('render');
+        return <MuiThemeProvider>
+            <main>
+		<BrowserRouter>
+	    		<nav>
+		    		<Link to='/chat/1'>Chat N1</Link>
+			    	<Link to='/chat/2'>Chat N2</Link>
+		    	</nav>
+
+			<Switch>
+				<Route exact path="/" component={Messages}/>
+				<Route path="/chat/:chatId" render={obj => <Messages chatId={obj.match.params.chatId}/>}/>
+			</Switch>
+
+		</BrowserRouter>
+            </main> 
+        </MuiThemeProvider>;
+    }
+}

--- a/src/components/Example.jsx
+++ b/src/components/Example.jsx
@@ -1,0 +1,27 @@
+import React, {Component} from 'react';
+import Message from './Message';
+
+export default class Example extends Component {
+    state = {
+        count: 0,
+        text: ''
+    };
+
+    click = (event) => {
+        this.setState({count: this.state.count + 1})
+    }
+
+    change = (event) => {
+        this.setState({text: event.target.value})
+    }
+
+    render() {
+        return <div>
+            <Message text={`Count click - ${this.state.count}`}/>
+            <button onClick={this.click}>+1</button>
+            <br/>
+            <Message text={this.state.text}/>
+            <input value={this.state.text} onChange={this.change}/>
+        </div>;
+    }
+}

--- a/src/components/Message.jsx
+++ b/src/components/Message.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import styles from '../styles/Message';
+
+// const Message = ({text}) => <span>{text}</span>;
+
+export default class Message extends React.Component {
+    static propTypes = {
+        message: PropTypes.string.isRequired,
+        author: PropTypes.string.isRequired
+    };
+
+    render() {
+        return <div style={{...styles.message, alignSelf: this.props.author === 'robot' ? 'flex-start' : 'flex-end'}}>
+            <div>{this.props.message}</div>
+            <div style={styles.author}>{this.props.author}</div>
+        </div>;
+    }
+}

--- a/src/components/MessageList.jsx
+++ b/src/components/MessageList.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Message from './Message';
+
+import '../styles/MessageList.css';
+
+export default class MessageList extends React.Component {
+    static propTypes = {
+        messages: PropTypes.array
+    };
+
+    static defaultProps = {
+        messages: []
+    };
+
+    render() {
+        return <div className={'messages'}>
+            { this.props.messages.map(({message, author}, id) => <><Message message={message} author={author} key={`message_${id}`}/><br/></>) }
+        </div>;
+    }
+}

--- a/src/components/SendMessage.jsx
+++ b/src/components/SendMessage.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+// import {TextField} from 'material-ui';
+import TextField from 'material-ui/TextField';
+// import Button from 'material-ui/RaisedButton';
+
+export default class SendMessage extends React.Component {
+    state = {
+        message: ''
+    };
+
+    static propTypes = {
+        send: PropTypes.func.isRequired
+    };
+
+    send = () => {
+        this.props.send({message: this.state.message, author: 'me'});
+        this.setState({message: ''});
+    };
+
+    handleChange = event => this.setState({message: event.target.value});
+
+    render() {
+        return <>
+            <TextField 
+                       value={this.state.message}
+                       onChange={this.handleChange} 
+                    //    fullWidth={true}
+                       multiline={true} 
+                       name={'message'}
+                    />
+            <button onClick={this.send}>Send</button>
+            </>;
+    }
+}

--- a/src/components/pages/Messages.jsx
+++ b/src/components/pages/Messages.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import MessageList from '../MessageList';
+import SendMessage from '../SendMessage';
+
+export default class Messages extends React.Component {
+	state = {
+		messages: []
+	};
+
+	static PropTypes = {
+		chatId: PropTypes.number,
+	};
+
+	static defaultProps = {
+		chatId: -1
+	};
+
+    	send = objMsg => {
+        	this.setState({messages: [...this.state.messages, objMsg]});
+    	};
+
+	render() {
+		return <>
+			<h2>{this.props.chatId}</h2>
+			<MessageList messages={this.state.messages}/>
+			<SendMessage send={this.send}/>
+		</>;
+	}
+}

--- a/src/helper.js
+++ b/src/helper.js
@@ -1,0 +1,5 @@
+const log1 = () => console.log('Useless function default');
+
+export function log(){console.log('Useless fucntion not default')};
+
+export default log1;

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <%= htmlWebpackPlugin.tags.headTags %>
+</head>
+<body>
+    <div id="root"></div>
+    <%= htmlWebpackPlugin.tags.bodyTags %>
+</body>
+</html>

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import App from './components/App.jsx';
+
+ReactDOM.render(
+    <App/>,
+    document.getElementById('root')
+);

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -1,0 +1,9 @@
+main {
+    height: 100%;
+   width: 50%;
+   margin: auto;
+   display: flex;
+   align-items: center;
+   justify-content: center;
+   flex-direction: column;
+}

--- a/src/styles/Message.js
+++ b/src/styles/Message.js
@@ -1,0 +1,13 @@
+export default {
+    message: {
+        backgroundColor: 'lightblue',
+        padding: '5px 15px',
+        borderRadius: '20px',
+        fontSize: '18px',
+        margin: '5px'
+    },
+    author: {
+        color: 'gray',
+        fontSize: '14px'
+    }
+};

--- a/src/styles/MessageList.css
+++ b/src/styles/MessageList.css
@@ -1,0 +1,9 @@
+.messages{
+    display: flex;
+   flex-direction: column;
+   background-color: #e2e2e2;
+   height: 50%;
+   width: 100%;
+   padding: 20px;
+   overflow-y: scroll;
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,49 @@
+ const path = require('path');
+ const HtmlWebpackPlugin = require('html-webpack-plugin');
+ const { CleanWebpackPlugin } = require('clean-webpack-plugin');
+ 
+ module.exports = {
+   mode: 'development',
+   entry: {
+     index: './index.jsx'
+   },
+   context: path.resolve(__dirname, 'src'),
+   devtool: 'inline-source-map',
+    devServer: {
+        contentBase: './dist',
+	historyApiFallback: {
+		index: 'index.html'
+	},
+    },
+      module: {
+          rules: [
+              {
+                test: /\.jsx?$/,
+                include: path.resolve(__dirname, 'src'),
+                exclude: path.resolve(__dirname, 'node_modules'),
+                loader: 'babel-loader',
+                options: {
+                    presets: ['@babel/env', '@babel/react'],
+                    plugins: ['@babel/plugin-proposal-class-properties']
+                }
+              },
+              {
+                test: /\.css$/,
+                use: ['style-loader', 'css-loader']
+              }
+          ]
+      },
+   plugins: [
+     new CleanWebpackPlugin({ cleanStaleWebpackAssets: false }),
+     new HtmlWebpackPlugin({
+       template: 'index.html'
+     }),
+   ],
+   output: {
+     filename: '[name].bundle.js',
+     path: path.resolve(__dirname, 'dist'),
+   },
+   resolve: {
+       extensions: ['.js', '.jsx']
+   }
+ };


### PR DESCRIPTION
### Этот PR содержит следующие выполненные задания

- [x] Подключить BrowserRouter (из react-router-dom).
- [x] Создать верхний компонент Router со Switch и Route’ами.
- [x] Разбить приложение на чаты с помощью роутера (URLs: /chat/<chat_id>/).
- [ ] Реализовать хранение сообщений в словаре с id в качестве ключа.
- [ ] Реализовать хранение чатов в словаре с id в качестве ключа, а в качестве значения со словарем из названия чата и списка id-шников сообщений из этого чата.
- [ ] Сделать страницу профиля, располагающуюся по пути /profile/, и ссылку на нее в Header’е мессенджера.

------------------------
P.S.: Работа над этим PR-ом продолжается. PR будет обновляться.
